### PR TITLE
Don't try to "normalice" a properly formed "url" object

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,12 @@ var freeice = module.exports = function(opts) {
     }
 
     return out.map(function(url) {
-      return normalice(type + ':' + url);
+        //If it's a not a string, don't try to "normalice" it otherwise using type:url will screw it up
+        if ((typeof url !== 'string') && (! (url instanceof String))) {
+            return url;
+        } else {
+            return normalice(type + ':' + url);
+        }
     });
   }
 


### PR DESCRIPTION
The current code uses type + ':' + url to "normalice" an url.
However if one wants to add an object (and not a string) to their list of either turn or stun servers, then this object is broken by this concatenation.

(Background note : the code of normalice splits the url based on @, so it becomes impossible to setup credentials of the form : email@domain:password@url. In this case we must use a proper "object" but then freeice breaks it without the change of this pull request).