### PR TITLE
Angular 2 build failed because of "var freeice = module.exports = ..." notaion

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ var normalice = require('normalice');
 
 **/
 
-var freeice = module.exports = function(opts) {
+var freeice = function(opts) {
   // if a list of servers has been provided, then use it instead of defaults
   var servers = {
     stun: (opts || {}).stun || require('./stun.json'),
@@ -103,3 +103,5 @@ var freeice = module.exports = function(opts) {
 
   return selected;
 };
+
+module.exports = freeice;


### PR DESCRIPTION
Hello
For some reason, angular 2 build failed to parse freeice script. After some debugging, found out that this line breaks parser:
https://github.com/DamonOehlman/freeice/blob/ed5affec16c81a5691d5f3f523afed0c922b862a/index.js#L66
Could you please consider merging this pr into main branch? This seems to fix the problem
Thanks